### PR TITLE
Add missing flag to git clone, vs2022 note

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,11 +9,13 @@ Although x86 is now available, unfortunately x86 cannot coexist with x64.
 ## 1. Install pyvtil first
 
 ```bash
-git clone -b dev-1 https://github.com/wallds/VTIL-Python.git
+git clone -b dev-1 https://github.com/wallds/VTIL-Python.git --recursive
 cd VTIL-Python
 py setup.py install --old-and-unmanageable
 ```
 **To use x86 you need to replace `dev-1` with `dev-x86`.**
+
+**If you are using Visual Studio 2022 build tools, then you need to update `extras` in setup.py from `Visual Studio 16 2019` to `Visual Studio 17 2022`**
 ## 2. Install plugin
 Copy novmpy&novmpy.py to IDA plugin directory.
 


### PR DESCRIPTION
added `--recursive` flag to git clone because we need to fetch all submodules from git repo along with the source (i can see that `setup.py` is clonning external libs if there are no libs, but in my case it still wouldn't allow to properly install, so `--recursive` flag fixed this issue ¯\\_(ツ)_/¯)
also added a note that you would need to update extras list in setup.py if you are trying to compile it on vs2022