### PR TITLE
Fix: Correct VMJmp handling logic for VMJmp instructions

### DIFF
--- a/novmpy/handler.py
+++ b/novmpy/handler.py
@@ -1847,7 +1847,7 @@ class VMJmp(VMBase):
                     if op1.reg in new_sp:
                         new_sp.remove(op1.reg)
                         new_sp.append(op2.reg)
-                    if op2.reg in new_sp:
+                    elif op2.reg in new_sp:
                         new_sp.remove(op2.reg)
                         new_sp.append(op1.reg)
                 elif instr_match(insn, X86_INS_MOV, [X86_OP_REG, X86_OP_REG]):


### PR DESCRIPTION
Added missing logic for `op2.reg in new_sp` in the `simple_parse` method of the `VMJmp` class. This ensures proper stack pointer updates during register exchanges.